### PR TITLE
Replace profanity with better_profanity and install it if it can't import

### DIFF
--- a/server-aurora.py
+++ b/server-aurora.py
@@ -2,6 +2,7 @@ import socket
 import threading
 import time
 import sys
+import subprocess
 
 # --- Auto-install missing dependency ---
 try:


### PR DESCRIPTION
also import subprocess to automatically install the module