### PR TITLE
Fix crash hopefully, and fix theme text bug

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -298,15 +298,6 @@ int main(int argc, char **argv) {
         
 
 
-        char *themetext;
-        sprintf(themetext, "%s:\n%s", "Current Theme", themename);
-
-        DrawText(themename, 170.0f, 0.0f, 0, 0.4f, 0.4f, textcolor, false);
-
-
-        
-
-
         if (scene == 1) {
             DrawText("aurorachat", 260.0f, 0.0f, 0, 1.0f, 1.0f, textcolor, false);
             
@@ -331,7 +322,7 @@ int main(int argc, char **argv) {
             
 
 
-            DrawText(themetext, 170.0f, 0.0f, 0, 0.4f, 0.4f, textcolor, false);
+            DrawText(themename, 170.0f, 0.0f, 0, 0.4f, 0.4f, textcolor, false);
 
         }
 


### PR DESCRIPTION
This also removes the duplicate theme text that gets rendered in the _rules_ scene and _main_ scene (I never even noticed it before).

I don't have a 3DS to test this on but in Azahar it cleared most errors in the log file (there were A LOT of errors). I'm literally going to sleep right now so I haven't been able to test it much but if it works, it works, if it doesn't then it doesn't and either way it fixes the aforementioned theme text bug that I described.

ok going to sleep now byyee
zzzzzzzzzzz