### PR TITLE
Improve Server Security

### DIFF
--- a/server-aurora.py
+++ b/server-aurora.py
@@ -127,7 +127,7 @@ def handle_client(client_socket, client_address):
     connection_times[client_ip] = now_ms
 
     clients.append(client_socket)
-    print(f"Client connection established: {client_ip}")
+    print(f"Client connection established.")
 
     try:
         buffer = ""


### PR DESCRIPTION
* **Removed automatic pip install**
This was a fault of mine in one of my previous pull requests. I now removed the automatic pip install on startup since it could _theoretically_ be used as an attack point. It's not likely but better safe than sorry ig.

To install the module manually with pip you just type `pip install better_profanity` in terminal.

* **Prevented ANSI escape sequences from printing in terminal**
ANSI escape sequences allow attackers to manipulate text appearances and behaviour using ANSI escape codes (documented at https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797). The main threat of this is that an attacker could clutter the logs with a bunch of junk and we don't want that.

* **Rate limit connections**
This is the most crucial change because an attacker could completely bypass the spam detection. While the server **does** rate limit messages, it **doesn't** rate limit connections. The variable that counts the last sent message gets reset everytime the client reconnects. An attacker could connect, send a message, disconnect and repeat for how long they would want.

~~oh and the client IP now gets printed once someone connects, for debugging purposes of course.~~